### PR TITLE
Create reusable list items for profile screen

### DIFF
--- a/components/ActivityItem.jsx
+++ b/components/ActivityItem.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { API_URL } from '../config';
+import localImages from '../utils/localImages';
+import ListItem from './ListItem';
+
+const ActivityItem = ({ item, onPress }) => {
+  let imageSource;
+  const uri = item.imageUrl;
+  if (uri) {
+    if (localImages[uri]) {
+      imageSource = localImages[uri];
+    } else if (!uri.startsWith('http')) {
+      imageSource = { uri: `${API_URL}/${uri}` };
+    } else {
+      imageSource = { uri };
+    }
+  }
+  const date = item.date || item.createdAt;
+  const formatted = date ? new Date(date).toLocaleDateString() : 'N/A';
+
+  return (
+    <ListItem
+      imageSource={imageSource}
+      title={item.title || item.name}
+      content={item.description}
+      date={formatted}
+      onPress={onPress}
+    />
+  );
+};
+
+export default ActivityItem;

--- a/components/EventItem.jsx
+++ b/components/EventItem.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { API_URL } from '../config';
+import localImages from '../utils/localImages';
+import ListItem from './ListItem';
+
+const EventItem = ({ item, onPress }) => {
+  let imageSource;
+  const uri = item.imageUrl;
+  if (uri) {
+    if (localImages[uri]) {
+      imageSource = localImages[uri];
+    } else if (!uri.startsWith('http')) {
+      imageSource = { uri: `${API_URL}/${uri}` };
+    } else {
+      imageSource = { uri };
+    }
+  }
+  const rawDate = item.date || item.startTime;
+  const formatted = rawDate ? new Date(rawDate).toLocaleDateString() : 'N/A';
+
+  return (
+    <ListItem
+      imageSource={imageSource}
+      title={item.title || item.name}
+      content={item.description || item.venue}
+      date={formatted}
+      onPress={onPress}
+    />
+  );
+};
+
+export default EventItem;

--- a/components/ListItem.jsx
+++ b/components/ListItem.jsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import FastImage from 'react-native-fast-image';
+import themeVariables from '../styles/theme';
+
+const ListItem = ({ imageSource, title, content, date, onPress }) => {
+  return (
+    <TouchableOpacity style={styles.container} onPress={onPress}>
+      {imageSource && (
+        <FastImage source={imageSource} style={styles.image} />
+      )}
+      <View style={styles.textContainer}>
+        {title && (
+          <Text style={styles.title} numberOfLines={1}>
+            {title}
+          </Text>
+        )}
+        {content && (
+          <Text style={styles.content} numberOfLines={2}>
+            {content}
+          </Text>
+        )}
+      </View>
+      {date && <Text style={styles.date}>{date}</Text>}
+    </TouchableOpacity>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#fff',
+    borderRadius: 8,
+    padding: 12,
+    marginHorizontal: 16,
+    marginVertical: 6,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.1,
+    shadowRadius: 2,
+    elevation: 2,
+  },
+  image: {
+    width: 60,
+    height: 60,
+    borderRadius: 8,
+    marginRight: 12,
+  },
+  textContainer: {
+    flex: 1,
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: themeVariables.primaryColor,
+  },
+  content: {
+    fontSize: 14,
+    color: '#312783',
+    marginTop: 4,
+  },
+  date: {
+    marginLeft: 8,
+    fontSize: 12,
+    color: '#555',
+  },
+});
+
+export default ListItem;

--- a/components/PostItem.jsx
+++ b/components/PostItem.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { API_URL } from '../config';
+import localImages from '../utils/localImages';
+import ListItem from './ListItem';
+
+const PostItem = ({ item, onPress }) => {
+  let imageSource;
+  const uri = item.media?.[0];
+  if (uri) {
+    if (localImages[uri]) {
+      imageSource = localImages[uri];
+    } else if (!uri.startsWith('http')) {
+      imageSource = { uri: `${API_URL}/${uri}` };
+    } else {
+      imageSource = { uri };
+    }
+  }
+  const date = item.createdAt || item.updatedAt;
+  const formatted = date ? new Date(date).toLocaleDateString() : 'N/A';
+
+  return (
+    <ListItem
+      imageSource={imageSource}
+      title={item.title}
+      content={item.content}
+      date={formatted}
+      onPress={onPress}
+    />
+  );
+};
+
+export default PostItem;

--- a/screens/Profile.jsx
+++ b/screens/Profile.jsx
@@ -14,7 +14,9 @@ import themeVariables from '../styles/theme';
 import FastImage from 'react-native-fast-image';
 import { TabView } from 'react-native-tab-view';
 import { UserContext } from '../contexts/UserContext';
-import PostGallery from '../components/PostGallery';
+import PostItem from '../components/PostItem';
+import ActivityItem from '../components/ActivityItem';
+import EventItem from '../components/EventItem';
 import { fetchActivities } from '../services/ActivityService';
 import { fetchEvents } from '../services/EventService';
 import { fetchExploreFeed } from '../services/PostService';
@@ -189,66 +191,23 @@ const renderList = (data, type) => {
     return <Text style={styles.noDataText}>No {type} available.</Text>;
   }
 
+  const ItemComponent =
+    type === 'posts' ? PostItem : type === 'activities' ? ActivityItem : EventItem;
+
   return (
     <FlatList
       data={data}
+      refreshing={refreshing}
+      onRefresh={onRefresh}
       keyExtractor={(item, index) =>
         item._id ? item._id.toString() : index.toString()
       }
-      renderItem={({ item }) => {
-        let rawDate;
-        if (type === 'events') rawDate = item.date || item.startTime;
-        else if (type === 'activities') rawDate = item.date || item.createdAt;
-        else if (type === 'posts') rawDate = item.createdAt || item.updatedAt;
-
-        let formattedDate = rawDate
-          ? new Date(rawDate).toLocaleDateString()
-          : 'N/A';
-
-        return (
-          <TouchableOpacity
-            style={styles.listItem}
-            onPress={() => handleItemPress(type, item)}
-          >
-            {type === 'posts' && item.content && (
-              <Text style={styles.listContent}>
-                {item.content.length > 100
-                  ? `${item.content.slice(0, 100)}...`
-                  : item.content}
-              </Text>
-            )}
-
-            {type === 'activities' && item.description && (
-              <>
-                <Text style={styles.listTitle}>{item.title || item.name}</Text>
-                <Text style={styles.listContent}>
-                  {item.description.length > 100
-                    ? `${item.description.slice(0, 100)}...`
-                    : item.description}
-                </Text>
-              </>
-            )}
-
-            {type === 'events' && (
-              <>
-                <Text style={styles.listTitle}>{item.title || item.name}</Text>
-                {item.venue && (
-                  <Text style={styles.listContent}>Venue: {item.venue}</Text>
-                )}
-                {item.description && (
-                  <Text style={styles.listContent}>
-                    {item.description.length > 100
-                      ? `${item.description.slice(0, 100)}...`
-                      : item.description}
-                  </Text>
-                )}
-              </>
-            )}
-
-            <Text style={styles.listDate}>{formattedDate}</Text>
-          </TouchableOpacity>
-        );
-      }}
+      renderItem={({ item }) => (
+        <ItemComponent
+          item={item}
+          onPress={() => handleItemPress(type, item)}
+        />
+      )}
     />
   );
 };
@@ -257,11 +216,11 @@ const renderList = (data, type) => {
 const renderScene = ({ route }) => {
   switch (route.key) {
     case 'posts':
-      return <PostGallery posts={posts} refreshing={refreshing} onRefresh={onRefresh} />;
+      return renderList(posts, 'posts');
     case 'activities':
-      return <PostGallery posts={activities} refreshing={refreshing} onRefresh={onRefresh} />;
+      return renderList(activities, 'activities');
     case 'events':
-      return <PostGallery posts={events} refreshing={refreshing} onRefresh={onRefresh} />;
+      return renderList(events, 'events');
     default:
       return null;
   }


### PR DESCRIPTION
## Summary
- implement generic `ListItem` component
- add specialized `PostItem`, `ActivityItem`, and `EventItem`
- show lists of posts, activities, and events in Profile screen using new components

## Testing
- `npm test` *(fails: Token not available and Jest unable to parse module)*

------
https://chatgpt.com/codex/tasks/task_e_6864999bcce88328b2bf99f78a3cab05