### PR TITLE
Replace leftover FA icons with Ionicons

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -36,7 +36,6 @@ import NotificationScreen from './screens/Notifications';
 import CreatePostScreen from './screens/CreatePost';
 import PostModal from './modal/PostModal';
 
-// FontAwesome library setup
 import Ionicons from 'react-native-vector-icons/Ionicons';
 
 const Stack = createNativeStackNavigator();

--- a/components/SessionCard.jsx
+++ b/components/SessionCard.jsx
@@ -32,14 +32,14 @@ const SessionCard = ({
   let statusIcon;
   switch (session.status) {
     case 'Scheduled':
-      statusIcon = faClock;
+      statusIcon = clockIcon;
       break;
     case 'Completed':
-      statusIcon = faCheckCircle;
+      statusIcon = checkCircle;
       break;
     case 'Cancelled':
     case 'Expired':
-      statusIcon = faTimesCircle;
+      statusIcon = timesCircle;
       break;
     default:
       statusIcon = null;

--- a/components/UserBadge.jsx
+++ b/components/UserBadge.jsx
@@ -22,16 +22,19 @@ const UserBadge = ({ user, userCertifications, type = 'user' }) => {
   let displayName = `${user.firstName || ''} ${user.lastName || ''}`.trim();
   let avatarUri = user.profilePicture || null;
   let certifications = [];
+  const verifiedIcon = 'checkmark-circle';
+  const protectionIcon = 'shield-checkmark';
+  const lsaIcon = 'star';
 
   if (type === 'user') {
     if (userCertifications?.isVerified) {
-      certifications.push({ iconName: faCheck, label: 'Verified User', style: styles.verifiedBadge });
+      certifications.push({ iconName: verifiedIcon, label: 'Verified User', style: styles.verifiedBadge });
     }
     if (userCertifications?.hasChildProtection) {
-      certifications.push({ iconName: faShieldAlt, label: 'Child Prot Cert.', style: styles.protectionBadge });
+      certifications.push({ iconName: protectionIcon, label: 'Child Prot Cert.', style: styles.protectionBadge });
     }
     if (userCertifications?.isLocalAssemblyMember) {
-      certifications.push({ iconName: faStar, label: 'LSA Member', style: styles.lsaBadge });
+      certifications.push({ iconName: lsaIcon, label: 'LSA Member', style: styles.lsaBadge });
     }
   }
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,7 +10,7 @@ module.exports = {
   // Transform specific modules that use ESM syntax
   transformIgnorePatterns: [
     // Allow ESM modules in react-native and selected packages to be transformed
-    'node_modules/(?!(react-native|@react-native|react-native-progress|react-native-config|@fortawesome)/)'
+    'node_modules/(?!(react-native|@react-native|react-native-progress|react-native-config|react-native-vector-icons)/)'
   ],
   moduleFileExtensions: ['js', 'jsx', 'ts', 'tsx', 'json', 'node'],
 };


### PR DESCRIPTION
## Summary
- remove leftover FontAwesome comment
- swap remaining FA icon references to Ionicons
- update Jest config to transform `react-native-vector-icons`

## Testing
- `npm test`
- `npm run lint` *(fails: many existing warnings and errors)*

------
https://chatgpt.com/codex/tasks/task_e_686d1e68cbc0832897a749ae09fad674