### PR TITLE
Introduce CommunityContext

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -3,7 +3,7 @@ import { StatusBar, StyleSheet, View } from 'react-native';
 import { SafeAreaProvider, initialWindowMetrics } from 'react-native-safe-area-context';
 import themeVariables from './styles/theme';
 
-import { UserProvider } from './contexts';
+import { UserProvider, CommunityProvider } from './contexts';
 import { useAppInitialization } from './hooks/useAppInitialization';
 
 import { Splash } from './screens';
@@ -36,9 +36,11 @@ const MainApp = () => {
 };
 
 const App = () => (
-  <UserProvider>
-    <MainApp />
-  </UserProvider>
+  <CommunityProvider>
+    <UserProvider>
+      <MainApp />
+    </UserProvider>
+  </CommunityProvider>
 );
 
 export default App;

--- a/__tests__/CreatePost.test.jsx
+++ b/__tests__/CreatePost.test.jsx
@@ -4,6 +4,7 @@ import CreatePost from '../modal/PostModal';
 import { launchImageLibrary, launchCamera } from 'react-native-image-picker';
 import { uploadImageWithThumbnail, uploadVideoWithThumbnail, createPost } from '../services/PostService';
 import { UserContext } from '../contexts/UserContext';
+import { CommunityContext } from '../contexts/CommunityContext';
 
 jest.mock('react-native-image-picker', () => ({
   launchImageLibrary: jest.fn(),
@@ -26,6 +27,13 @@ describe('CreatePost screen', () => {
     token: 'token123',
     user: { id: 'user123' },
   };
+  const communityContextValue = {
+    communityId: 'community123',
+    setCommunityId: jest.fn(),
+    homeOverview: null,
+    setHomeOverview: jest.fn(),
+    storageLoaded: true,
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -38,9 +46,9 @@ describe('CreatePost screen', () => {
     });
 
     const { getByText, getByTestId, queryByTestId } = render(
-      <UserContext.Provider value={userContextValue}>
+      <CommunityContext.Provider value={communityContextValue}><UserContext.Provider value={userContextValue}>
         <CreatePost />
-      </UserContext.Provider>
+      </UserContext.Provider></CommunityContext.Provider>
     );
 
     fireEvent.press(getByText('Upload image or video'));
@@ -57,9 +65,9 @@ describe('CreatePost screen', () => {
     });
 
     const { getByText, getByTestId, queryByTestId } = render(
-      <UserContext.Provider value={userContextValue}>
+      <CommunityContext.Provider value={communityContextValue}><UserContext.Provider value={userContextValue}>
         <CreatePost />
-      </UserContext.Provider>
+      </UserContext.Provider></CommunityContext.Provider>
     );
 
     fireEvent.press(getByText('Upload image or video'));
@@ -76,9 +84,9 @@ describe('CreatePost screen', () => {
     });
 
     const { getByText, getByTestId, queryByTestId } = render(
-      <UserContext.Provider value={userContextValue}>
+      <CommunityContext.Provider value={communityContextValue}><UserContext.Provider value={userContextValue}>
         <CreatePost />
-      </UserContext.Provider>
+      </UserContext.Provider></CommunityContext.Provider>
     );
 
     fireEvent.press(getByText('Upload image or video'));
@@ -95,9 +103,9 @@ describe('CreatePost screen', () => {
     });
 
     const { getByText, getByTestId, queryByTestId } = render(
-      <UserContext.Provider value={userContextValue}>
+      <CommunityContext.Provider value={communityContextValue}><UserContext.Provider value={userContextValue}>
         <CreatePost />
-      </UserContext.Provider>
+      </UserContext.Provider></CommunityContext.Provider>
     );
 
     fireEvent.press(getByText('Upload image or video'));
@@ -114,9 +122,9 @@ describe('CreatePost screen', () => {
     });
 
     const { getByText, getByTestId, queryByTestId } = render(
-      <UserContext.Provider value={userContextValue}>
+      <CommunityContext.Provider value={communityContextValue}><UserContext.Provider value={userContextValue}>
         <CreatePost />
-      </UserContext.Provider>
+      </UserContext.Provider></CommunityContext.Provider>
     );
 
     fireEvent.press(getByText('Upload image or video'));
@@ -139,9 +147,9 @@ describe('CreatePost screen', () => {
 
     const onPostCreated = jest.fn();
     const { getByText, getByPlaceholderText, getByTestId } = render(
-      <UserContext.Provider value={userContextValue}>
+      <CommunityContext.Provider value={communityContextValue}><UserContext.Provider value={userContextValue}>
         <CreatePost onPostCreated={onPostCreated} />
-      </UserContext.Provider>
+      </UserContext.Provider></CommunityContext.Provider>
     );
 
     fireEvent.press(getByText('Upload image or video'));
@@ -187,9 +195,9 @@ describe('CreatePost screen', () => {
 
     const onPostCreated = jest.fn();
     const { getByText, getByPlaceholderText, getByTestId } = render(
-      <UserContext.Provider value={userContextValue}>
+      <CommunityContext.Provider value={communityContextValue}><UserContext.Provider value={userContextValue}>
         <CreatePost onPostCreated={onPostCreated} />
-      </UserContext.Provider>
+      </UserContext.Provider></CommunityContext.Provider>
     );
 
     fireEvent.press(getByText('Upload image or video'));

--- a/__tests__/SocialMedia.test.jsx
+++ b/__tests__/SocialMedia.test.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, waitFor } from '@testing-library/react-native';
 import SocialMedia from '../screens/SocialMedia';
 import { UserContext } from '../contexts/UserContext';
+import { CommunityContext } from '../contexts/CommunityContext';
 import * as PostService from '../services/PostService';
 // Mock the Post component to avoid internal implementation details
 jest.mock('../components/Post', () => {
@@ -37,6 +38,13 @@ describe('SocialMedia screen', () => {
     refreshSession: jest.fn(),
     user: { id: 'user123' },
   };
+  const communityContextValue = {
+    communityId: 'community123',
+    setCommunityId: jest.fn(),
+    homeOverview: null,
+    setHomeOverview: jest.fn(),
+    storageLoaded: true,
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -57,9 +65,9 @@ describe('SocialMedia screen', () => {
     PostService.fetchForYouFeed.mockResolvedValue([]);
 
     const { getByTestId } = render(
-      <UserContext.Provider value={userContextValue}>
+      <CommunityContext.Provider value={communityContextValue}><UserContext.Provider value={userContextValue}>
         <SocialMedia />
-      </UserContext.Provider>
+      </UserContext.Provider></CommunityContext.Provider>
     );
 
     // Wait for explore feed to load
@@ -85,9 +93,11 @@ describe('SocialMedia screen', () => {
     PostService.fetchForYouFeed.mockResolvedValue([]);
 
     const { getByTestId } = render(
-      <UserContext.Provider value={userContextValue}>
-        <SocialMedia />
-      </UserContext.Provider>
+      <CommunityContext.Provider value={communityContextValue}>
+        <UserContext.Provider value={userContextValue}>
+          <SocialMedia />
+        </UserContext.Provider>
+      </CommunityContext.Provider>
     );
 
     // Wait for explore feed to load

--- a/contexts/CommunityContext.jsx
+++ b/contexts/CommunityContext.jsx
@@ -1,0 +1,71 @@
+import React, { createContext, useState, useEffect } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { API_URL } from '../config';
+
+export const CommunityContext = createContext();
+
+export const CommunityProvider = ({ children }) => {
+  const [communityId, setCommunityId] = useState(null);
+  const [homeOverview, setHomeOverview] = useState(null);
+  const [storageLoaded, setStorageLoaded] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const [idPair, overviewPair] = await AsyncStorage.multiGet([
+          'communityId',
+          'homeOverview',
+        ]);
+        if (idPair[1]) setCommunityId(idPair[1]);
+        if (overviewPair[1]) setHomeOverview(JSON.parse(overviewPair[1]));
+      } catch (err) {
+        console.error('Failed to load community cache:', err);
+      } finally {
+        setStorageLoaded(true);
+      }
+    })();
+  }, []);
+
+  const fetchHomeOverview = async (id) => {
+    try {
+      const response = await fetch(`${API_URL}/api/auth/homeOverview/${id}`, {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      const data = await response.json();
+      return { ok: response.ok, data };
+    } catch (error) {
+      console.error('Home overview fetch error:', error);
+      return { ok: false };
+    }
+  };
+
+  useEffect(() => {
+    if (!communityId) return;
+    (async () => {
+      try {
+        const result = await fetchHomeOverview(communityId);
+        if (result.ok) {
+          setHomeOverview(result.data);
+          await AsyncStorage.setItem('homeOverview', JSON.stringify(result.data));
+        } else {
+          console.warn('Failed to fetch home overview');
+        }
+      } catch (err) {
+        console.error('Error fetching home overview:', err);
+      }
+    })();
+  }, [communityId]);
+
+  return (
+    <CommunityContext.Provider value={{
+      communityId,
+      setCommunityId,
+      homeOverview,
+      setHomeOverview,
+      storageLoaded,
+    }}>
+      {children}
+    </CommunityContext.Provider>
+  );
+};

--- a/contexts/UserContext.jsx
+++ b/contexts/UserContext.jsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState, useEffect } from 'react';
+import React, { createContext, useState, useEffect, useContext } from 'react';
 import NotificationService from '../services/NotificationService';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as Keychain from 'react-native-keychain';
@@ -7,13 +7,14 @@ import { fetchEvents } from '../services/EventService.jsx';
 import { fetchExploreFeed } from '../services/PostService.jsx';
 import { parseJwt } from '../utils/parseJwt';
 import { API_URL } from '../config';
+import { CommunityContext } from './CommunityContext';
 
 export const UserContext = createContext();
 
 export const UserProvider = ({ children }) => {
   const [user, setUser] = useState(null);
   const [token, setToken] = useState(null);
-  const [communityId, setCommunityId] = useState(null);
+  const { setCommunityId } = useContext(CommunityContext);
   const [userActivities, setUserActivities] = useState(null);
   const [userEvents, setUserEvents] = useState(null);
   const [userPosts, setUserPosts] = useState(null);
@@ -30,7 +31,6 @@ export const UserProvider = ({ children }) => {
           'authToken',
           'refreshToken',
           'user',
-          'communityId',
           'userActivities',
           'userEvents',
           'userPosts',
@@ -41,8 +41,6 @@ export const UserProvider = ({ children }) => {
         if (map.authToken) setToken(map.authToken);
         if (map.refreshToken) setRefreshToken(map.refreshToken);
         if (map.user) setUser(JSON.parse(map.user));
-        // Set communityId from storage, even if empty string
-        if (map.communityId !== undefined) setCommunityId(map.communityId);
 
         if (map.userActivities)
           setUserActivities(JSON.parse(map.userActivities));
@@ -92,7 +90,7 @@ export const UserProvider = ({ children }) => {
     };
 
     loadUserData();
-  }, [communityId, token]);
+  }, [token]);
 
   const login = async (userData, authToken, refreshToken, email, password) => {
     try {
@@ -285,8 +283,6 @@ export const UserProvider = ({ children }) => {
         setUnreadCount,
         userNotifications,
         setUserNotifications,
-        communityId,
-        setCommunityId,
         login,
         logout,
         isLoggedIn: !!token,

--- a/contexts/index.js
+++ b/contexts/index.js
@@ -1,1 +1,2 @@
 export { UserProvider, UserContext } from './UserContext';
+export { CommunityProvider, CommunityContext } from './CommunityContext';

--- a/hooks/useAppInitialization.js
+++ b/hooks/useAppInitialization.js
@@ -1,6 +1,6 @@
 import { useState, useEffect, useContext } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { UserContext } from '../contexts';
+import { UserContext, CommunityContext } from '../contexts';
 import { fetchExploreFeed, useAuthService } from '../services';
 
 /**
@@ -10,25 +10,22 @@ import { fetchExploreFeed, useAuthService } from '../services';
 export const useAppInitialization = () => {
   const [appIsReady, setAppIsReady] = useState(false);
   const [initialPosts, setInitialPosts] = useState([]);
-  const [homeOverview, setHomeOverview] = useState([]);
-  const [homeOverviewLoaded, setHomeOverviewLoaded] = useState(false);
   const [checkingSession, setCheckingSession] = useState(true);
   const [showSplash, setShowSplash] = useState(true);
 
-  const { biometricLogin, isLoggedIn, communityId, storageLoaded,
+  const { biometricLogin, isLoggedIn, storageLoaded,
           token, isTokenExpired, refreshSession } = useContext(UserContext);
+  const { communityId, homeOverview, setHomeOverview } = useContext(CommunityContext);
   const { fetchHomeOverview } = useAuthService();
 
-  // Load cached posts and overview for immediate display
+  // Load cached posts for immediate display
   useEffect(() => {
     (async () => {
       try {
-        const [postsPair, overviewPair] = await AsyncStorage.multiGet([
+        const [postsPair] = await AsyncStorage.multiGet([
           'initialExploreFeed',
-          'homeOverview',
         ]);
         if (postsPair[1]) setInitialPosts(JSON.parse(postsPair[1]));
-        if (overviewPair[1]) setHomeOverview(JSON.parse(overviewPair[1]));
       } catch (err) {
         console.warn('Failed to load cached data:', err);
       }
@@ -83,26 +80,6 @@ export const useAppInitialization = () => {
     refreshSession,
   ]);
 
-  // Fetch home overview independently
-  useEffect(() => {
-    if (!communityId) return;
-    setHomeOverviewLoaded(false);
-    (async () => {
-      try {
-        const result = await fetchHomeOverview(communityId);
-        if (result.ok) {
-          setHomeOverview(result.data);
-          await AsyncStorage.setItem('homeOverview', JSON.stringify(result.data));
-        } else {
-          console.warn('Failed to fetch home overview');
-        }
-      } catch (error) {
-        console.error('Error fetching home overview:', error);
-      } finally {
-        setHomeOverviewLoaded(true);
-      }
-    })();
-  }, [communityId, fetchHomeOverview]);
 
   // Hide splash once minimal data is ready
   useEffect(() => {
@@ -126,4 +103,5 @@ export const useAppInitialization = () => {
     })();
   }, [showSplash, token, isTokenExpired, fetchExploreFeed]);
 
-  return { initialPosts, homeOverview, showSplash };};
+  return { initialPosts, homeOverview, showSplash };
+};

--- a/modal/PostModal.jsx
+++ b/modal/PostModal.jsx
@@ -18,6 +18,7 @@ import { launchImageLibrary } from 'react-native-image-picker';
 import Ionicons from 'react-native-vector-icons/Ionicons';
 import themeVariables from '../styles/theme';
 import { UserContext } from '../contexts/UserContext';
+import { CommunityContext } from '../contexts/CommunityContext';
 import { createPost, uploadImageWithThumbnail, uploadVideoWithThumbnail } from '../services/PostService';
 
 const PostModal = ({ visible = true, onPostCreated, onClose }) => {
@@ -27,7 +28,8 @@ const PostModal = ({ visible = true, onPostCreated, onClose }) => {
   const [isUploading, setIsUploading] = useState(false);
   const [uploadProgress, setUploadProgress] = useState(0);
   const [uploadStep, setUploadStep] = useState('');
-  const { communityId, token, user, userActivities, userEvents } = useContext(UserContext);
+  const { token, user, userActivities, userEvents } = useContext(UserContext);
+  const { communityId } = useContext(CommunityContext);
   const [tags, setTags] = useState([]);
   const [dropdownOpen, setDropdownOpen] = useState(false);
 

--- a/screens/CreatePost.jsx
+++ b/screens/CreatePost.jsx
@@ -21,6 +21,7 @@ import * as Progress from 'react-native-progress';
 import Video from 'react-native-video';
 import { launchCamera, launchImageLibrary } from 'react-native-image-picker';
 import { UserContext } from '../contexts/UserContext';
+import { CommunityContext } from '../contexts/CommunityContext';
 import { TouchableWithoutFeedback } from 'react-native';
 import { createPost, uploadImageWithThumbnail, uploadVideoWithThumbnail } from '../services/PostService';
 import themeVariables from '../styles/theme';
@@ -31,7 +32,8 @@ export default function CreatePost({ onPostCreated, onClose }) {
   const [mediaType, setMediaType] = useState(null);
   const [isUploading, setIsUploading] = useState(false);
   const [uploadStep, setUploadStep] = useState('');
-  const { communityId, token, user, userActivities, userEvents } = useContext(UserContext);
+  const { token, user, userActivities, userEvents } = useContext(UserContext);
+  const { communityId } = useContext(CommunityContext);
   const [uploadProgress, setUploadProgress] = useState(0);
   const [tags, setTags] = useState([]);
   const [dropdownOpen, setDropdownOpen] = useState(false);

--- a/screens/EventDetail.jsx
+++ b/screens/EventDetail.jsx
@@ -12,13 +12,15 @@ import {
 } from 'react-native';
 import themeVariables from '../styles/theme';
 import { UserContext } from '../contexts/UserContext';
+import { CommunityContext } from '../contexts/CommunityContext';
 import { joinEvent, fetchEventDetails } from '../services/EventService';
 import localImages from '../utils/localImages';
 import Ionicons from 'react-native-vector-icons/Ionicons';
 
 const EventDetail = ({ route }) => {
   const { event: initialEvent, eventId } = route.params || {};
-  const { user, token, communityId } = useContext(UserContext);
+  const { user, token } = useContext(UserContext);
+  const { communityId } = useContext(CommunityContext);
 
   const [event, setEvent] = useState(initialEvent || null);
   const [loading, setLoading] = useState(!initialEvent);

--- a/screens/EventDetailCard.jsx
+++ b/screens/EventDetailCard.jsx
@@ -32,6 +32,7 @@ import UserCell from '../components/UserCell';
 // import OversightBadges from '../components/OversightBadges'; // unused, replaced by avatars
 import { fetchUserBodyByEventType } from '../services/UserBodyService';
 import { UserContext } from '../contexts/UserContext';
+import { CommunityContext } from '../contexts/CommunityContext';
 import { API_URL } from '../config';
 // Amount to offset content so top corners are hidden initially
 const HEADER_OFFSET = 0;
@@ -106,7 +107,8 @@ const EventDetailCard = ({ route }) => {
       ),
     });
   }, [navigation, event]);
-  const { user, token, communityId } = useContext(UserContext);
+  const { user, token } = useContext(UserContext);
+  const { communityId } = useContext(CommunityContext);
   const [optimisticJoin, setOptimisticJoin] = useState(false);
 
   // Fetch full event details in the background and update state
@@ -159,7 +161,8 @@ const EventDetailCard = ({ route }) => {
 
 const EventCardBody = ({ event, setEvent, userId, token, optimisticJoin, setOptimisticJoin, oversightMembersPreload }) => {
   // Access current user and community from context for joining
-  const { user, communityId } = useContext(UserContext);
+  const { user } = useContext(UserContext);
+  const { communityId } = useContext(CommunityContext);
   // Destructure raw attendees from event; we'll enrich with full user data below
   const { imageUrl, title, eventType, date, startTime, endTime, venue,
     attendees: rawAttendees = [], host, materials = [] } = event;

--- a/screens/Home.jsx
+++ b/screens/Home.jsx
@@ -17,6 +17,7 @@ import Ionicons from 'react-native-vector-icons/Ionicons';
 import themeVariables from '../styles/theme';
 import Carousel from '../components/Carousel';
 import { UserContext } from '../contexts/UserContext';
+import { CommunityContext } from '../contexts/CommunityContext';
 import { useFocusEffect, useIsFocused } from '@react-navigation/native';
 import { getBadiDate } from '../utils/badiDate';
 import SquareTile from '../components/SquareTile';
@@ -61,7 +62,8 @@ const Home = ({ navigation, homeOverview }) => {
   // Extra padding to further push content down and enlarge banner
   const EXTRA_TOP = 50;
   const bannerHeight = 200 + statusBarHeight + EXTRA_TOP;
-  const { user, communityId, userActivities, userEvents, userPosts, token, isTokenExpired, refreshSession, unreadCount } = useContext(UserContext);
+  const { user, userActivities, userEvents, userPosts, token, isTokenExpired, refreshSession, unreadCount } = useContext(UserContext);
+  const { communityId } = useContext(CommunityContext);
   const isFocused = useIsFocused();
   const bannerData = useMemo(() => {
     const bi = user?.community?.bannerImage;

--- a/screens/RequestAgendaItem.jsx
+++ b/screens/RequestAgendaItem.jsx
@@ -11,10 +11,12 @@ import {
 import { TextInput, Button, Title, HelperText } from 'react-native-paper';
 import { sendAgendaItemSuggestion } from '../services/AssemblyService';
 import { UserContext } from '../contexts/UserContext';
+import { CommunityContext } from '../contexts/CommunityContext';
 import themeVariables from '../styles/theme';
 
 export default function RequestAgendaItem({ navigation, route }) {
-  const { communityId, token } = useContext(UserContext);
+  const { token } = useContext(UserContext);
+  const { communityId } = useContext(CommunityContext);
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [errors, setErrors] = useState({});

--- a/screens/SocialMedia.jsx
+++ b/screens/SocialMedia.jsx
@@ -17,12 +17,14 @@ import { likePost, commentOnPost, fetchExploreFeed, fetchForYouFeed, flagPost, d
 import { blockUser, muteUser } from '../services/UserService';
 import themeVariables from '../styles/theme';
 import { UserContext } from '../contexts/UserContext';
+import { CommunityContext } from '../contexts/CommunityContext';
 import Post from '../components/Post';
 import WelcomeModal from '../modal/WelcomeModal';
 import CommentModal from '../modal/CommentModal';
 
 const SocialMedia = ({ initialPosts, scrollToTop, route, navigation }) => {
-  const { token, communityId, isTokenExpired, refreshSession, user } = useContext(UserContext);
+  const { token, isTokenExpired, refreshSession, user } = useContext(UserContext);
+  const { communityId } = useContext(CommunityContext);
   // Debug logs removed
   const [activeTab, setActiveTab] = useState('explore');
   const [explorePosts, setExplorePosts] = useState(initialPosts || []);


### PR DESCRIPTION
## Summary
- add new CommunityContext to handle community data
- wrap application with CommunityProvider
- load and fetch home overview inside CommunityContext
- refactor useAppInitialization and screens to use CommunityContext
- update tests for new provider structure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ed4b1ee108328b3a1542bba9b4989