### PR TITLE
Fix iOS Associated Domains config

### DIFF
--- a/ios/liquid_spirit_mobile_app.xcodeproj/project.pbxproj
+++ b/ios/liquid_spirit_mobile_app.xcodeproj/project.pbxproj
@@ -267,7 +267,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_ENTITLEMENTS = liquid_spirit_mobile_app/Entitlements.plist;
+                               CODE_SIGN_ENTITLEMENTS = liquid_spirit_mobile_app/liquid_spirit_mobile_app.entitlements;
 				CURRENT_PROJECT_VERSION = 101;
 				DEVELOPMENT_TEAM = 7MGG8ZRN25;
 				ENABLE_BITCODE = NO;
@@ -300,7 +300,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_ENTITLEMENTS = liquid_spirit_mobile_app/Entitlements.plist;
+                               CODE_SIGN_ENTITLEMENTS = liquid_spirit_mobile_app/liquid_spirit_mobile_app.entitlements;
 				CURRENT_PROJECT_VERSION = 101;
 				DEVELOPMENT_TEAM = 7MGG8ZRN25;
 				ENABLE_TESTING_SEARCH_PATHS = NO;

--- a/ios/liquid_spirit_mobile_app/Info.plist
+++ b/ios/liquid_spirit_mobile_app/Info.plist
@@ -89,10 +89,5 @@
 		<string>NSUserActivityTypeBrowsingWeb</string>
 	</array>
 
-	<key>AssociatedDomains</key>
-	<array>
-		<string>applinks:liquidspirit.org</string>
-		<string>applinks:www.liquidspirit.org</string>
-	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- ensure the app target uses the proper entitlements file
- remove stray `AssociatedDomains` from `Info.plist`

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6882f24ded20832898bd10d5de918197