### PR TITLE
Enhance validation for auth-related forms

### DIFF
--- a/screens/ForgotPassword.jsx
+++ b/screens/ForgotPassword.jsx
@@ -9,6 +9,7 @@ import {
 } from 'react-native';
 import { useAuthService } from '../services/AuthService';
 import themeVariables from '../styles/theme';
+import { isValidEmail } from '../utils/validation';
 
 const ForgotPassword = ({ navigation }) => {
   const [email, setEmail] = useState('');
@@ -19,6 +20,11 @@ const ForgotPassword = ({ navigation }) => {
   const handleForgotPassword = async () => {
     if (!email) {
       Alert.alert('Error', 'Please enter an email address.');
+      return;
+    }
+
+    if (!isValidEmail(email)) {
+      Alert.alert('Error', 'Please enter a valid email address.');
       return;
     }
 

--- a/screens/Login.jsx
+++ b/screens/Login.jsx
@@ -4,6 +4,7 @@ import themeVariables from '../styles/theme';
 import { UserContext } from '../contexts/UserContext';
 import * as Keychain from 'react-native-keychain';
 import { API_URL } from '../config';
+import { isValidEmail, isValidPassword } from '../utils/validation';
 
 const Login = ({ navigation }) => {
   const [email, setEmail] = useState('');
@@ -41,6 +42,19 @@ const Login = ({ navigation }) => {
   const handleLogin = async () => {
     if (!email || !password) {
       Alert.alert('Error', 'Please enter both email and password.');
+      return;
+    }
+
+    if (!isValidEmail(email)) {
+      Alert.alert('Error', 'Please enter a valid email address.');
+      return;
+    }
+
+    if (!isValidPassword(password)) {
+      Alert.alert(
+        'Error',
+        'Password must be at least 8 characters and include a number and a letter. Special characters are allowed.'
+      );
       return;
     }
 

--- a/screens/Register.jsx
+++ b/screens/Register.jsx
@@ -12,6 +12,11 @@ import Ionicons from 'react-native-vector-icons/Ionicons';
 import { useAuthService } from '../services/AuthService';
 import { useNavigation } from '@react-navigation/native';
 import themeVariables from '../styles/theme';
+import {
+  isValidEmail,
+  isValidBahaiId,
+  isValidPassword,
+} from '../utils/validation';
 
 const Register = () => {
   const navigation = useNavigation();
@@ -30,8 +35,26 @@ const Register = () => {
       return;
     }
 
+    if (!isValidEmail(email)) {
+      Alert.alert('Error', 'Please enter a valid email address.');
+      return;
+    }
+
+    if (!isValidBahaiId(bahaiId)) {
+      Alert.alert('Error', "Bahá'í ID must contain only numbers.");
+      return;
+    }
+
     if (password !== confirmPassword) {
       Alert.alert('Error', 'Passwords do not match.');
+      return;
+    }
+
+    if (!isValidPassword(password)) {
+      Alert.alert(
+        'Error',
+        'Password must be at least 8 characters and include a number and a letter. Special characters are allowed.'
+      );
       return;
     }
 
@@ -77,7 +100,7 @@ const Register = () => {
       <TextInput
         style={styles.input}
         value={bahaiId}
-        onChangeText={setBahaiId}
+        onChangeText={(text) => setBahaiId(text.replace(/[^0-9]/g, ''))}
         keyboardType="numeric"
       />
       {/* Password Label and Input */}

--- a/utils/validation.js
+++ b/utils/validation.js
@@ -1,0 +1,15 @@
+export const isValidEmail = (email) => {
+  const emailRegex = /^\S+@\S+\.\S+$/;
+  return emailRegex.test(String(email).toLowerCase());
+};
+
+export const isValidBahaiId = (id) => {
+  const bahaiIdRegex = /^\d+$/;
+  return bahaiIdRegex.test(id);
+};
+
+export const isValidPassword = (password) => {
+  // Minimum eight characters, at least one letter and one number; special characters allowed
+  const passwordRegex = /^(?=.*[A-Za-z])(?=.*\d).{8,}$/;
+  return passwordRegex.test(password);
+};


### PR DESCRIPTION
## Summary
- allow Bahá'í ID inputs of any length while restricting to digits and filtering non-numeric characters
- permit special characters in password validation and update feedback across Register and Login screens

## Testing
- `npm test`
- `npm run lint` *(fails: 886 problems: 128 errors, 758 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68917afc76a08328a825213f4a75184d