### PR TITLE
Add system dark mode theme support

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -1,9 +1,9 @@
 // no direct React hooks needed; initialization logic moved to useAppInitialization hook
 import React, { useEffect, useContext } from 'react';
-import { StatusBar, StyleSheet, View, Linking } from 'react-native';
+import { StatusBar, StyleSheet, View, Linking, useColorScheme } from 'react-native';
 import { SafeAreaProvider, initialWindowMetrics } from 'react-native-safe-area-context';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
-import themeVariables from './styles/theme';
+import { getThemeVariables } from './styles/theme';
 
 import { UserProvider, CommunityProvider, ChatProvider, VenuesProvider } from './contexts';
 import { useAppInitialization } from './hooks/useAppInitialization';
@@ -18,6 +18,8 @@ import debugLog from './utils/debugLog';
 const MainApp = () => {
   const { initialPosts, homeOverview, showSplash } = useAppInitialization();
   const { token } = useContext(UserContext);
+  const scheme = useColorScheme();
+  const themeVariables = getThemeVariables(scheme);
 
   useMountEffect(() => {
     Linking.getInitialURL().then(url => {
@@ -51,7 +53,7 @@ const MainApp = () => {
     <SafeAreaProvider initialMetrics={initialWindowMetrics}>
       <View style={styles.root}>
         <StatusBar
-          barStyle={showSplash ? 'light-content' : 'dark-content'}
+          barStyle={showSplash ? 'light-content' : scheme === 'dark' ? 'light-content' : 'dark-content'}
           backgroundColor={showSplash ? themeVariables.primaryColor : themeVariables.whiteColor}
         />
         {showSplash ? (

--- a/__tests__/theme.test.js
+++ b/__tests__/theme.test.js
@@ -1,0 +1,26 @@
+import { getThemeVariables } from '../styles/theme';
+import { getColors } from '../styles/colours';
+
+describe('theme support', () => {
+  it('returns dark palette when dark scheme is provided', () => {
+    const theme = getThemeVariables('dark');
+    const colors = getColors('dark');
+
+    expect(theme.screenBackgroundColor).toBe('#0b1220');
+    expect(theme.whiteColor).toBe('#0b1220');
+    expect(theme.blackColor).toBe('#f8fafc');
+    expect(colors.background).toBe('#0b1220');
+    expect(colors.text).toBe('#f8fafc');
+  });
+
+  it('returns light palette when light scheme is provided', () => {
+    const theme = getThemeVariables('light');
+    const colors = getColors('light');
+
+    expect(theme.screenBackgroundColor).toBe('#ffffff');
+    expect(theme.whiteColor).toBe('#ffffff');
+    expect(theme.blackColor).toBe('#000000');
+    expect(colors.background).toBe('#ecf0f1');
+    expect(colors.text).toBe('#2c3e50');
+  });
+});

--- a/navigation/AppNavigator.jsx
+++ b/navigation/AppNavigator.jsx
@@ -1,8 +1,9 @@
 import React, { useContext } from 'react';
-import { NavigationContainer } from '@react-navigation/native';
+import { DarkTheme, DefaultTheme, NavigationContainer } from '@react-navigation/native';
 import { navigationRef, flushPendingNavigation } from './RootNavigation';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import themeVariables from '../styles/theme';
+import { useColorScheme } from 'react-native';
+import { getThemeVariables } from '../styles/theme';
 import LiquidGlassIconButton from '../components/LiquidGlassIconButton';
 
 const linking = {
@@ -57,9 +58,13 @@ const Stack = createNativeStackNavigator();
 const AppNavigator = ({ initialPosts, homeOverview }) => {
   const { isLoggedIn, ensureValidSession } = useContext(UserContext);
   const initialRoute = isLoggedIn ? 'Main' : 'Welcome';
+  const scheme = useColorScheme();
+  const themeVariables = getThemeVariables(scheme);
+  const navigationTheme = scheme === 'dark' ? DarkTheme : DefaultTheme;
 
   return (
     <NavigationContainer
+      theme={navigationTheme}
       linking={linking}
       ref={navigationRef}
       onReady={flushPendingNavigation}

--- a/styles/colours.js
+++ b/styles/colours.js
@@ -1,7 +1,21 @@
-export const colors = {
+import { Appearance } from 'react-native';
+
+const lightColors = {
   primary: '#312783',
   secondary: '#3FA7A1',
   background: '#ecf0f1',
   text: '#2c3e50',
   error: '#e74c3c',
 };
+
+const darkColors = {
+  primary: '#8b7cf5',
+  secondary: '#63c7c2',
+  background: '#0b1220',
+  text: '#f8fafc',
+  error: '#f87171',
+};
+
+export const getColors = scheme => (scheme === 'dark' ? darkColors : lightColors);
+
+export const colors = getColors(Appearance.getColorScheme());

--- a/styles/theme.js
+++ b/styles/theme.js
@@ -1,79 +1,104 @@
-const themeVariables = {
-    blueColor: '#0a488c',
-    greenColor: '#58db33',
-    redColor: '#e52f2f',
-    pinkColor: '#fc59f8',
-    greyColor: '#f3f3f3',
-    blackColor: '#000000',
-    whiteColor: '#ffffff',
+import { Appearance } from 'react-native';
 
-    // These will need manual color adjustments, as React Native doesn't support LESS functions like 'lighten' and 'darken'
-    lightGreyColor: '#f3f3f3', // Lighter grey (adjust manually)
-    darkGreyColor: '#e0e0e0',  // Darker grey (adjust manually)
+const spacing = {
+  xs: 4,
+  s: 8,
+  m: 12,
+  l: 16,
+  xl: 24,
+  xxl: 32,
+};
 
-    primaryColor: '#312783', // This references blueColor, so we replace it
-    primaryLightColor: '#3578a8', // Adjust this manually to be lighter blue
-    primaryLighterColor: '#5b9ac8', // Even lighter blue
+const baseTheme = {
+  blueColor: '#0a488c',
+  greenColor: '#58db33',
+  redColor: '#e52f2f',
+  pinkColor: '#fc59f8',
+  greyColor: '#f3f3f3',
+  blackColor: '#000000',
+  whiteColor: '#ffffff',
 
-    secondaryColor: '#58db33',
-    secondaryLightColor: '#72e457', // Adjust this manually to be lighter green
-    secondaryDarkColor: '#44b628',  // Darker green
+  lightGreyColor: '#f3f3f3',
+  darkGreyColor: '#e0e0e0',
 
-    tertiaryColor: '#fc59f8',
-    tertiaryLightColor: '#ff85fc', // Lighter pink
-    tertiaryDarkColor: '#e046d1',  // Darker pink
+  primaryColor: '#312783',
+  primaryLightColor: '#3578a8',
+  primaryLighterColor: '#5b9ac8',
 
-    neutralLight: '#f3f3f3',  // General light grey
-    neutralDark: '#e0e0e0',   // General dark grey
+  secondaryColor: '#58db33',
+  secondaryLightColor: '#72e457',
+  secondaryDarkColor: '#44b628',
 
-    buttonPrimaryBg: '#0a488c',
-    buttonPrimaryHoverBg: '#3578a8', // Hover for primary button
-    buttonSecondaryBg: '#58db33',
-    buttonSecondaryHoverBg: '#72e457', // Hover for secondary button
-    buttonDisabledBg: '#f3f3f3', // Disabled button background
-    buttonDisabledText: '#b3b3b3', // Lighter disabled button text
+  tertiaryColor: '#fc59f8',
+  tertiaryLightColor: '#ff85fc',
+  tertiaryDarkColor: '#e046d1',
 
-    borderColor: '#e0e0e0',  // Dark grey for borders
-    borderLightColor: '#f3f3f3',  // Light grey for light borders
+  neutralLight: '#f3f3f3',
+  neutralDark: '#e0e0e0',
 
-    screenBackgroundColor: '#ffffff',
+  buttonPrimaryBg: '#0a488c',
+  buttonPrimaryHoverBg: '#3578a8',
+  buttonSecondaryBg: '#58db33',
+  buttonSecondaryHoverBg: '#72e457',
+  buttonDisabledBg: '#f3f3f3',
+  buttonDisabledText: '#b3b3b3',
 
-    menuBgColor: '#0a488c',
-    menuTextColor: '#ffffff', // Assuming text inverse color is white
-    menuHoverBg: '#58db33',
-    menuHoverText: '#ffffff',
+  borderColor: '#e0e0e0',
+  borderLightColor: '#f3f3f3',
 
-    formInputBg: '#ffffff',
-    formInputBorder: '#e0e0e0',
-    formInputFocusBorder: '#0a488c',
-    formErrorBorder: '#e52f2f',  // Assuming error color is red
-    formSuccessBorder: '#58db33', // Assuming success color is green
+  screenBackgroundColor: '#ffffff',
 
-    alertSuccessBg: '#58db33',
-    alertErrorBg: '#e52f2f',
-    alertWarningBg: '#ffcc00', // Assuming a standard warning color
-    alertTextColor: '#ffffff',
+  menuBgColor: '#0a488c',
+  menuTextColor: '#ffffff',
+  menuHoverBg: '#58db33',
+  menuHoverText: '#ffffff',
 
-    fontFamily: "'Noto Sans', sans-serif",
+  formInputBg: '#ffffff',
+  formInputBorder: '#e0e0e0',
+  formInputFocusBorder: '#0a488c',
+  formErrorBorder: '#e52f2f',
+  formSuccessBorder: '#58db33',
 
-    borderRadiusSharp: 0,
-    borderRadiusPill: 20,
-    borderRadiusJumbo: 44,
+  alertSuccessBg: '#58db33',
+  alertErrorBg: '#e52f2f',
+  alertWarningBg: '#ffcc00',
+  alertTextColor: '#ffffff',
 
-    boxShadowCard: 'rgba(0, 0, 0, 0.16) 0px 10px 36px 0px, rgba(0, 0, 0, 0.06) 0px 0px 0px 1px',
-    boxShadowInfo: '0px 0px 12px -9px',
+  fontFamily: "'Noto Sans', sans-serif",
+  borderRadiusSharp: 0,
+  borderRadiusPill: 20,
+  borderRadiusJumbo: 44,
+  boxShadowCard: 'rgba(0, 0, 0, 0.16) 0px 10px 36px 0px, rgba(0, 0, 0, 0.06) 0px 0px 0px 1px',
+  boxShadowInfo: '0px 0px 12px -9px',
+  spacing,
+  pad: 10,
+  margin: 10,
+};
 
-    spacing: {
-      xs: 4,
-      s: 8,
-      m: 12,
-      l: 16,
-      xl: 24,
-      xxl: 32,
-    },
+const darkTheme = {
+  ...baseTheme,
+  greyColor: '#111827',
+  blackColor: '#f8fafc',
+  whiteColor: '#0b1220',
+  lightGreyColor: '#1f2937',
+  darkGreyColor: '#334155',
+  neutralLight: '#111827',
+  neutralDark: '#334155',
+  buttonDisabledBg: '#1f2937',
+  buttonDisabledText: '#94a3b8',
+  borderColor: '#334155',
+  borderLightColor: '#1f2937',
+  screenBackgroundColor: '#0b1220',
+  menuBgColor: '#111827',
+  menuTextColor: '#f8fafc',
+  formInputBg: '#111827',
+  formInputBorder: '#334155',
+  alertTextColor: '#f8fafc',
+  boxShadowCard: 'rgba(0, 0, 0, 0.5) 0px 10px 36px 0px, rgba(0, 0, 0, 0.2) 0px 0px 0px 1px',
+};
 
-    pad: 10,
-    margin: 10,
-  };
+export const getThemeVariables = scheme => (scheme === 'dark' ? darkTheme : baseTheme);
 
-  export default themeVariables;
+const themeVariables = getThemeVariables(Appearance.getColorScheme());
+
+export default themeVariables;


### PR DESCRIPTION
### Motivation
- Provide first-class dark mode support so the app follows the OS appearance and uses appropriate palettes across screens. 
- Centralize theme/semantic colors to make it easy for screens/components to use the active scheme. 
- Ensure navigation chrome (status bar and headers) and shared color helpers are scheme-aware.

### Description
- Add scheme-aware palettes in `styles/theme.js` and expose `getThemeVariables(scheme)` while keeping a default export for backward compatibility. 
- Add semantic light/dark colors in `styles/colours.js` and expose `getColors(scheme)` with `colors` still available via `Appearance`. 
- Wire system appearance into the app root by calling `useColorScheme()` in `App.jsx` and using `getThemeVariables(scheme)` for status bar colors. 
- Wire React Navigation to use `DarkTheme` / `DefaultTheme` and use `getThemeVariables(scheme)` for header/background colors in `navigation/AppNavigator.jsx`. 
- Add `__tests__/theme.test.js` to validate both light and dark palette outputs from the new helpers.

### Testing
- Ran lint with `yarn lint` and it succeeded. 
- Ran unit tests with `yarn test --watch=false`; new theme tests (`__tests__/theme.test.js`) passed but the overall test run failed due to an existing unrelated timeout in `__tests__/SocialMedia.test.jsx` (`renders image posts after fetching explore feed`). 
- Confirmed `__tests__/theme.test.js` asserts expected color values for both `getThemeVariables('dark'|'light')` and `getColors('dark'|'light')` and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0996d7e42c832886f29f572d6e77b6)